### PR TITLE
Fixed bug that did not display user's Spotify playlists

### DIFF
--- a/app/src/main/java/com/github/fribourgsdp/radio/MainActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/MainActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
-import com.github.fribourgsdp.radio.databinding.ActivityMainBinding
 import android.widget.ImageButton
 
 class MainActivity : AppCompatActivity() {
@@ -30,11 +29,13 @@ class MainActivity : AppCompatActivity() {
 
         /** this user allows quick demo's as it is data that is written to the app
          * specific storage and can be easily read without intents */
-        val mockUser = User("Saved User", User.generateColor())
-        val mockPlaylist1 = Playlist("test playlist", Genre.COUNTRY)
-        val mockPlaylist2 = Playlist("empty playlist", Genre.NONE)
-        mockPlaylist1.addSongs(setOf(Song("test Song 1", "test artist1"), Song("test Song 2", "test artist2")))
-        mockUser.addPlaylists(setOf(mockPlaylist1, mockPlaylist2))
-        mockUser.save(this)
+        if (intent.getBooleanExtra(RECREATE_USER, true)){
+            val mockUser = User("Saved User", User.generateColor())
+            val mockPlaylist1 = Playlist("test playlist", Genre.COUNTRY)
+            val mockPlaylist2 = Playlist("empty playlist", Genre.NONE)
+            mockPlaylist1.addSongs(setOf(Song("test Song 1", "test artist1"), Song("test Song 2", "test artist2")))
+            mockUser.addPlaylists(setOf(mockPlaylist1, mockPlaylist2))
+            mockUser.save(this)
+        }
     }
 }

--- a/app/src/main/java/com/github/fribourgsdp/radio/Playlist.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/Playlist.kt
@@ -3,7 +3,7 @@ package com.github.fribourgsdp.radio
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Playlist (var name: String, var genre: Genre){
+data class Playlist (var name: String, var genre: Genre): java.io.Serializable{
 
     private val songs: MutableSet<Song> = mutableSetOf()
 

--- a/app/src/main/java/com/github/fribourgsdp/radio/Song.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/Song.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 import java.util.concurrent.CompletableFuture
 
 @Serializable
-class Song (private val rawName: String, private val rawArtist: String, var lyrics: String){
+class Song (private val rawName: String, private val rawArtist: String, var lyrics: String): java.io.Serializable{
 
     val name: String = reformatName(rawName)
     val artist: String = reformatName(rawArtist)

--- a/app/src/main/java/com/github/fribourgsdp/radio/User.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/User.kt
@@ -21,7 +21,7 @@ class User (val name: String, val color: Int) {
 
     private val playlists = mutableSetOf<Playlist>()
     private val playlistNamesToSpotifyId = mutableMapOf<String, String>()
-    private var linkedSpotify: Boolean = false
+    var linkedSpotify: Boolean = false
     val initial get(): Char = name.elementAt(0)
     val spotifyLinked get(): Boolean = linkedSpotify
 


### PR DESCRIPTION
Adding the java.io.Serializable implementation to the Playlist and Song class removed an error that occured when passing a HashSet of Playlist through an Intent. 

If this PR is merged to the master branch, it will allow the user's Spotify playlists to be displayed in the User Profile Activity and these will be saved in the app specific storage as well.

This PR also makes sure that once a user logs in to Spotify on the app, his Spotify status is marked as linked in the user profile display.