### PR TITLE
Refactor java.io.serializable

### DIFF
--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/UserTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/UserTest.kt
@@ -31,7 +31,7 @@ class UserTest {
         val user = User(string)
         Assert.assertEquals(string, user.name)
         Assert.assertEquals(true, user.getPlaylists().isEmpty())
-        Assert.assertEquals(false, user.spotifyLinked)
+        Assert.assertEquals(false, user.linkedSpotify)
         Assert.assertEquals(string[0], user.initial)
     }
 

--- a/app/src/main/java/com/github/fribourgsdp/radio/Playlist.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/Playlist.kt
@@ -3,7 +3,18 @@ package com.github.fribourgsdp.radio
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Playlist (var name: String, var genre: Genre): java.io.Serializable{
+/**
+ * A data class for playlists
+ * Serializable: supports the use of Json.encodeToString(<playlist>)
+ * and Json.decodeFromString(<string>) so that it can be saved and loaded to files
+ * or passed through intents as strings
+ * (NOT as serializable Objects in intents, those implement Java.io.serializable)
+ *
+ * @property name name of the playlist
+ * @property genre genre of the playlist
+ * @constructor creates a Playlist with the given name and genre
+ */
+data class Playlist (var name: String, var genre: Genre) {
 
     private val songs: MutableSet<Song> = mutableSetOf()
 
@@ -13,23 +24,45 @@ data class Playlist (var name: String, var genre: Genre): java.io.Serializable{
 
     constructor(playlistName: String): this(playlistName, Genre.NONE)
 
-
+    /**
+     * Adds a single song to the playlist
+     * @param song the song to add
+     */
     fun addSong(song: Song){
         songs.add(song)
     }
 
+    /**
+     * Adds multiple songs to the playlist
+     * @param addedSongs the Set of songs to add
+     */
     fun addSongs(addedSongs: Set<Song>){
         songs.addAll(addedSongs)
     }
 
+    /**
+     * removes a single song from the playlist
+     * @param song the song to remove
+     */
     fun removeSong(song: Song){
         songs.remove(song)
     }
 
+    /**
+     * removes multiple songs from the playlist
+     * @param removedSongs the Set of songs to remove
+     */
     fun removeSongs(removedSongs: Set<Song>){
         songs.removeAll(removedSongs)
     }
 
+    /**
+     * transforms this playlist to contains the song of another playlist,
+     * and possible change this playlists genre
+     * @param other the playlist from which we should retrieve the songs
+     * @param newName the new name to give to this playlist; defaults to current name
+     * @param newGenre the new genre to give to this playlist; defaults to NONE
+     */
     fun combinePlaylists(other: Playlist, newName: String = name, newGenre: Genre = Genre.NONE) {
         name = newName
         genre = newGenre
@@ -38,6 +71,10 @@ data class Playlist (var name: String, var genre: Genre): java.io.Serializable{
         }
     }
 
+    /**
+     * getter for the songs in the playlist
+     * @return a copy of the songs in the playlist
+     */
     fun getSongs(): Set<Song> {
         return songs.toSet()
     }

--- a/app/src/main/java/com/github/fribourgsdp/radio/Song.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/Song.kt
@@ -5,14 +5,25 @@ import kotlinx.serialization.Serializable
 import java.util.concurrent.CompletableFuture
 
 @Serializable
-class Song (private val rawName: String, private val rawArtist: String, var lyrics: String): java.io.Serializable{
-
+/**
+ * A data class for songs with immutable name and artist but mutable lyrics.
+ * Serializable: supports the use of Json.encodeToString(<song>) and Json.decodeFromString(<string>)
+ * so that it can be saved and loaded to files or passed through intents as strings
+ * (NOT as serializable Objects in intents, those implement Java.io.serializable)
+ *
+ * @property rawName name of the song which will be reformatted and accessible with <song>.name
+ * @property rawArtist name of the artist which will be reformatted and accessible with <song>.artist
+ * @property lyrics mutable lyrics of the song
+ * @property name the reformatted name of the song
+ * @property artist the reformatted name of the artist of the song
+ * @constructor creates a Song with the given name, artist name and possibly blank lyrics
+ */
+class Song (private val rawName: String, private val rawArtist: String, var lyrics: String) {
     val name: String = reformatName(rawName)
     val artist: String = reformatName(rawArtist)
 
     constructor(name: String, artist: String): this(name, artist,"")
     constructor(name: String, artist: String, lyrics: CompletableFuture<String>): this(name, artist, lyrics.get())
-
 
     private fun reformatName(unformattedName: String): String {
         val noSpacesRegex = Regex(" +")

--- a/app/src/main/java/com/github/fribourgsdp/radio/User.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/User.kt
@@ -12,7 +12,21 @@ import java.io.File
 const val USER_DATA_PATH = "user_data_file"
 
 @Serializable
-class User (val name: String, val color: Int) {
+/**
+ * A data class for users with playlists
+ * Serializable: supports the use of Json.encodeToString(<user>)
+ * and Json.decodeFromString(<string>) so that it can be saved and loaded to files
+ * or passed through intents as strings
+ * (NOT as serializable Objects in intents, those implement Java.io.serializable)
+ *
+ * @property name name of the user (immutable)
+ * @property color color associated to the user for use in game (immutable)
+ * @property linkedSpotify true if User has successfully linked their spotify account
+ * @property initial the initial of the user's name to use as visual user identification with their color
+ *
+ * @constructor creates a User
+ */
+data class User (val name: String, val color: Int) {
     init {
         require(name.isNotEmpty() && name.isNotBlank())
     }
@@ -23,41 +37,89 @@ class User (val name: String, val color: Int) {
     private val playlistNamesToSpotifyId = mutableMapOf<String, String>()
     var linkedSpotify: Boolean = false
     val initial get(): Char = name.elementAt(0)
-    val spotifyLinked get(): Boolean = linkedSpotify
 
     companion object {
-        fun load( context: Context, path: String = USER_DATA_PATH) : User {
+        /**
+         * loads a user from the app-specific storage on the device.
+         * There can only be a single User stored on the device at the default path
+         * which is written with <user>.save().
+         * This function can be used from any activity of the app and retrieves the same data
+         *
+         * @param context the context to use for loading from a file (usually <this> in an activity)
+         * @param path a specific path in app-specific storage if we don't want to use the default
+         *      user location
+         * @throws java.io.FileNotFoundException
+         *
+         * @return the user saved on the device
+         */
+        fun load(context: Context, path: String = USER_DATA_PATH) : User {
             val userFile = File(context.filesDir, path)
             return Json.decodeFromString<User>(userFile.readText())
         }
 
+        /**
+         * generates a random color Int which can be used for a User's color param
+         */
         fun generateColor(): Int = (255 shl 24) or
                 (Random.nextInt(100, 200) shl 16) or
                 (Random.nextInt(100, 200) shl 8) or
                 Random.nextInt(100, 200)
     }
 
-    fun save(context: Context){
-        val userFile = File(context.filesDir, USER_DATA_PATH)
+    /**
+     * saves a user to the app-specific storage on the device.
+     * There can only be a single User stored on the device at the default path
+     * This function can be used from any activity of the app to save data accessible from anywhere
+     *
+     * @param context the context to use for saving to a file (usually <this> in an activity)
+     * @param path a specific path in app-specific storage if we don't want to use the default
+     *      user location
+     */
+    fun save(context: Context, path: String = USER_DATA_PATH){
+        val userFile = File(context.filesDir, path)
         userFile.writeText(Json.encodeToString(this))
     }
 
+    /**
+     * Adds a single playlist to the user's set of playlists
+     *
+     * @param playlist the playlist to add
+     */
     fun addPlaylist(playlist: Playlist){
         playlists.add(playlist)
     }
 
+    /**
+     * Adds multiple playlists to the user's set of playlists
+     *
+     * @param addedPlaylists the set of playlists to add
+     */
     fun addPlaylists(addedPlaylists: Set<Playlist>){
         playlists.addAll(addedPlaylists)
     }
 
+    /**
+     * removes a single playlist from the user's set of playlists
+     *
+     * @param playlist the playlist to remove
+     */
     fun removePlaylist(playlist: Playlist){
         playlists.remove(playlist)
     }
 
+    /**
+     * removes a set of playlists from the user's set of playlists
+     *
+     * @param removedPlaylist the playlists to remove
+     */
     fun removePlaylists(removedPlaylist: Set<Playlist>){
         playlists.removeAll(removedPlaylist)
     }
 
+    /**
+     * getter for the playlists of a user
+     * @return a copy of the playlists of a user
+     */
     fun getPlaylists(): Set<Playlist> {
         return playlists.toSet()
     }

--- a/app/src/main/java/com/github/fribourgsdp/radio/UserProfileActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/UserProfileActivity.kt
@@ -65,7 +65,7 @@ class UserProfileActivity : AppCompatActivity(), PlaylistAdapter.OnPlaylistClick
             PorterDuffColorFilter(user.color, PorterDuff.Mode.ADD)
 
         findViewById<TextView>(R.id.spotifyStatus).apply {
-            text = if (user.spotifyLinked) "linked" else "unlinked"
+            text = if (user.linkedSpotify) "linked" else "unlinked"
         }
 
 


### PR DESCRIPTION
Important Pull Request to only use a single type of serialization in the project.
Please use Kotlin Serialization in the future with the @Serializable decorator instead of implementing Java.io.serializable
The choice has been made to keep Kotlin's implementation of Serializable instead of Java's because it makes writing to files much easier.

If you wish to use a Serializable class with Intents, you simply need to convert the instance to a string and pass it as an Extra string to the intent.
Example:
 val intent = Intent(this, PlaylistDisplayActivity::class.java)
            .putExtra(PLAYLIST_DATA, Json.encodeToString(userPlaylists[position]))
/////
Json.decodeFromString(intent.getStringExtra(PLAYLIST_DATA)!!)