### PR TITLE
Ensure users with same name are visible in lobby with mic permissions

### DIFF
--- a/app/src/main/java/com/github/fribourgsdp/radio/FirestoreDatabase.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/FirestoreDatabase.kt
@@ -269,7 +269,7 @@ class FirestoreDatabase(var refMake: FirestoreRef) : Database {
             transaction.update(docRef, "players", mapIdToName)
 
             val playerPermissions = snapshot.get("permissions")!! as HashMap<String, Boolean>
-            playerPermissions[user.name] = hasMicPermissions
+            playerPermissions[user.id] = hasMicPermissions
 
             transaction.update(docRef, "permissions", playerPermissions)
 
@@ -289,7 +289,7 @@ class FirestoreDatabase(var refMake: FirestoreRef) : Database {
             }
 
             val playerPermissions = snapshot.get("permissions")!! as HashMap<String, Boolean>
-            playerPermissions[user.name] = newPermissions
+            playerPermissions[user.id] = newPermissions
 
             transaction.update(docRef, "permissions", playerPermissions)
 

--- a/app/src/main/java/com/github/fribourgsdp/radio/LobbyActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/LobbyActivity.kt
@@ -1,10 +1,8 @@
 package com.github.fribourgsdp.radio
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.drawable.Drawable
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
@@ -167,7 +165,7 @@ open class LobbyActivity : AppCompatActivity(){
         recyclerView.adapter = layoutAdapter
         if (isHost) {
             val hostMicPermissionsImg = if (hasVoiceIdPermissions) MIC_PERMISSIONS_ENABLED_DRAWABLE else NO_MIC_PERMISSIONS_DRAWABLE
-            layoutAdapter?.setContent(arrayOf(user.name), intArrayOf(hostMicPermissionsImg))
+            layoutAdapter?.setContent(arrayListOf(Pair(user.id, user.name)), intArrayOf(hostMicPermissionsImg))
             layoutAdapter?.notifyDataSetChanged()
         }
     }
@@ -244,11 +242,11 @@ open class LobbyActivity : AppCompatActivity(){
 
                 val isGameLaunched = snapshot.getBoolean("launched")
 
-                val mapNameToPermissions = snapshot.get("permissions")!! as HashMap<String, Boolean>
-                val atLeastOnePermissionMissing = mapNameToPermissions.containsValue(false)
+                val mapIdToPermissions = snapshot.get("permissions")!! as HashMap<String, Boolean>
+                val atLeastOnePermissionMissing = mapIdToPermissions.containsValue(false)
                 launchGameButton.isEnabled = !atLeastOnePermissionMissing
 
-                updateLobbyWithPlayers(newMap, mapNameToPermissions)
+                updateLobbyWithPlayers(newMap, mapIdToPermissions)
 
 
                 if (!isHost && isGameLaunched != null && isGameLaunched) {
@@ -263,17 +261,17 @@ open class LobbyActivity : AppCompatActivity(){
     }
 
     private fun updateLobbyWithPlayers(playersMap: Map<String, String>, nameToPermissions: Map<String, Boolean>) {
-        val users = playersMap.values
         val micPermissions = arrayListOf<Int>()
-        for (user in users) {
-            if (nameToPermissions[user]!!) {
+        val users = arrayListOf<Pair<String, String>>()
+        for ((userId, userName) in playersMap) {
+            if (nameToPermissions[userId]!!) {
                 micPermissions.add(MIC_PERMISSIONS_ENABLED_DRAWABLE)
-            }
-            else {
+            } else {
                 micPermissions.add(NO_MIC_PERMISSIONS_DRAWABLE)
             }
+            users.add(Pair(userId, userName))
         }
-        layoutAdapter?.setContent(users.toTypedArray(), micPermissions.toIntArray())
+        layoutAdapter?.setContent(users, micPermissions.toIntArray())
         layoutAdapter?.notifyDataSetChanged()
 
         gameBuilder.setUserIdList(playersMap.keys)

--- a/app/src/main/java/com/github/fribourgsdp/radio/RecyclerLobbyAdapter.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/RecyclerLobbyAdapter.kt
@@ -9,7 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 
 class RecyclerLobbyAdapter: RecyclerView.Adapter<RecyclerLobbyAdapter.LobbyListViewEntry>() {
 
-    private var userNames: Array<String> = arrayOf()
+    //Each element is a tuple (userId, userName)
+    private var userNames: List<Pair<String, String>> = arrayListOf()
     private var micImages = intArrayOf()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LobbyListViewEntry {
@@ -18,7 +19,7 @@ class RecyclerLobbyAdapter: RecyclerView.Adapter<RecyclerLobbyAdapter.LobbyListV
     }
 
     override fun onBindViewHolder(holder: LobbyListViewEntry, position: Int) {
-        holder.userName.text = userNames[position]
+        holder.userName.text = userNames[position].second
         holder.micImage.setImageResource(micImages[position])
     }
 
@@ -26,7 +27,7 @@ class RecyclerLobbyAdapter: RecyclerView.Adapter<RecyclerLobbyAdapter.LobbyListV
         return userNames.size
     }
 
-    fun setContent(newUsers: Array<String>, newImages: IntArray) {
+    fun setContent(newUsers: List<Pair<String, String>>, newImages: IntArray) {
         userNames = newUsers
         micImages = newImages
     }


### PR DESCRIPTION
If merged, this PR will ensure if multiple users in a lobby have the same name, they are both displayed as well as their mic permissions.