### PR TITLE
Bug fix - Correct popup tests

### DIFF
--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/AddPlaylistActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/AddPlaylistActivityTest.kt
@@ -1,15 +1,9 @@
 package com.github.fribourgsdp.radio
 
 import android.content.Context
-import android.os.Bundle
-import android.view.View
-import androidx.fragment.app.testing.launchFragment
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.*
-import androidx.test.espresso.UiController
-import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
@@ -17,22 +11,19 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
-import androidx.test.espresso.intent.matcher.IntentMatchers.*
- import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
 import com.google.android.gms.tasks.Tasks
-import org.junit.After
-import org.junit.Assert.*
-import org.junit.Before
-import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.*
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/AddPlaylistActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/AddPlaylistActivityTest.kt
@@ -297,6 +297,7 @@ class AddPlaylistActivityTest {
             .check(matches(isDisplayed()))
 
         onView(withId(R.id.validateQuitAddPlaylist))
+            .inRoot(isDialog())
             .perform(click())
 
         Intents.intended(
@@ -326,6 +327,7 @@ class AddPlaylistActivityTest {
             .check(matches(isDisplayed()))
 
         onView(withId(R.id.cancelQuitAddPlaylist))
+            .inRoot(isDialog())
             .perform(click())
 
         onView(withId(R.id.addSongToPlaylistSongName))

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
@@ -3,7 +3,6 @@ package com.github.fribourgsdp.radio
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
@@ -15,15 +14,13 @@ import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.fribourgsdp.radio.utils.CustomMatchers.Companion.atPosition
 import com.github.fribourgsdp.radio.mockimplementations.MockGameActivity
+import com.github.fribourgsdp.radio.utils.CustomMatchers.Companion.atPosition
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
@@ -54,6 +54,7 @@ class GameActivityTest {
         ActivityScenario.launch<MockGameActivity>(testIntent).use { _ ->
             Espresso.pressBack()
             onView(withId(R.id.cancelQuitGameOrLobby))
+                .inRoot(isDialog())
                 .perform(ViewActions.click())
         }
     }
@@ -64,6 +65,7 @@ class GameActivityTest {
         ActivityScenario.launch<MockGameActivity>(testIntent).use { _ ->
             Espresso.pressBack()
             Espresso.onView(withId(R.id.validateQuitGameOrLobby))
+                .inRoot(isDialog())
                 .perform(ViewActions.click())
         }
     }

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
@@ -221,6 +221,7 @@ class GameActivityTest {
 
             // Check that the scores are displayed with the correct data and in the correct order
             onView(withId(R.id.scoresRecyclerView))
+            onView(withId(R.id.scoresRecyclerView))
                 .check(matches(allOf(
                     atPosition(0, R.id.nameScoreTextView, withText("singer2")),
                     atPosition(0, R.id.scoreTextView, withText("100")),
@@ -238,11 +239,13 @@ class GameActivityTest {
         ActivityScenario.launch<GameActivity>(testIntent).use { scenario ->
             scenario.onActivity {
                 it.displayLyrics("Lorem ipsum, dolor sit amet")
-//                assertTrue(it.supportFragmentManager.fragments.any{f -> f.tag == "lyricsPopup"})
             }
-            onView(withId(R.id.close_popup_button)).perform(ViewActions.click())
+            onView(withId(R.id.close_popup_button))
+                .inRoot(isDialog())
+                .perform(ViewActions.click())
             Thread.sleep(1)
-            onView(withId(R.id.showLyricsButton)).check(matches(isDisplayed()))
+            onView(withId(R.id.showLyricsButton))
+                .check(matches(isDisplayed()))
 
         }
     }

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/GameActivityTest.kt
@@ -221,7 +221,6 @@ class GameActivityTest {
 
             // Check that the scores are displayed with the correct data and in the correct order
             onView(withId(R.id.scoresRecyclerView))
-            onView(withId(R.id.scoresRecyclerView))
                 .check(matches(allOf(
                     atPosition(0, R.id.nameScoreTextView, withText("singer2")),
                     atPosition(0, R.id.scoreTextView, withText("100")),

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/WorkingLobbyActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/WorkingLobbyActivityTest.kt
@@ -8,7 +8,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.fribourgsdp.radio.mockimplementations.LocalDatabase
@@ -16,7 +16,6 @@ import com.github.fribourgsdp.radio.mockimplementations.LyricsGettingWorkingLobb
 import com.github.fribourgsdp.radio.mockimplementations.WorkingLobbyActivity
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.hamcrest.Matchers
 import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -69,6 +68,7 @@ class WorkingLobbyActivityTest {
         ActivityScenario.launch<WorkingLobbyActivity>(testIntent).use{
             Espresso.pressBack()
             Espresso.onView(withId(R.id.cancelQuitGameOrLobby))
+                .inRoot(isDialog())
                 .perform(ViewActions.click())
         }
     }
@@ -79,6 +79,7 @@ class WorkingLobbyActivityTest {
         ActivityScenario.launch<WorkingLobbyActivity>(testIntent).use{
             Espresso.pressBack()
             Espresso.onView(withId(R.id.validateQuitGameOrLobby))
+                .inRoot(isDialog())
                 .perform(ViewActions.click())
         }
     }


### PR DESCRIPTION
Add root checks when tests use dialogs.

> When testing dialogs (popups), don't forget to do `.inRoot(isDialog())` before every `.check` or `.perform` so that the test gets the focus of the dialog right away and doesn't fail.