### PR TITLE
232 172 bug fix settings test undefined behaviour

### DIFF
--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/activities/SettingsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/activities/SettingsActivityTest.kt
@@ -22,13 +22,14 @@ import com.github.fribourgsdp.radio.MainActivity
 import com.github.fribourgsdp.radio.R
 import com.github.fribourgsdp.radio.config.SettingsActivity
 import com.github.fribourgsdp.radio.config.language.Language
+import com.github.fribourgsdp.radio.mockimplementations.MockSettingsActivity
 import org.hamcrest.Matchers.*
 
 
 @RunWith(AndroidJUnit4::class)
 class SettingsActivityTest {
   @get:Rule
-    var settingsActivityRule = ActivityScenarioRule(SettingsActivity::class.java)
+    var settingsActivityRule = ActivityScenarioRule(MockSettingsActivity::class.java)
 
     private val ctx: Context = ApplicationProvider.getApplicationContext()
 
@@ -56,8 +57,8 @@ class SettingsActivityTest {
     @Test
     fun saveSettingsWork() {
         val context: Context = ApplicationProvider.getApplicationContext()
-        val intent = Intent(context, SettingsActivity::class.java)
-        ActivityScenario.launch<SettingsActivity>(intent).use { scenario ->
+        val intent = Intent(context, MockSettingsActivity::class.java)
+        ActivityScenario.launch<MockSettingsActivity>(intent).use { scenario ->
 
             val spinnerId = Espresso.onView(ViewMatchers.withId(R.id.spinner_language))
 

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/mockimplementations/MockFileSystem.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/mockimplementations/MockFileSystem.kt
@@ -3,16 +3,16 @@ package com.github.fribourgsdp.radio.mockimplementations
 import android.content.Context
 import com.github.fribourgsdp.radio.persistence.FileSystem
 
-var data: String = ""
+var data: HashMap<String, String> = HashMap()
 
 class MockFileSystem : FileSystem {
 
     override fun write(path: String, string: String) {
-        data = string
+        data[path] = string
     }
 
     override fun read(path: String): String {
-        return data
+        return data[path]!!
     }
 
     companion object MockFSGetter : FileSystem.FileSystemGetter {
@@ -21,7 +21,7 @@ class MockFileSystem : FileSystem {
         }
 
         fun wipeData() {
-            data = ""
+            data = HashMap()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/mockimplementations/MockSettingsActivity.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/mockimplementations/MockSettingsActivity.kt
@@ -1,0 +1,15 @@
+package com.github.fribourgsdp.radio.mockimplementations
+
+import android.content.Context
+import android.os.Bundle
+import com.github.fribourgsdp.radio.config.Settings
+import com.github.fribourgsdp.radio.config.SettingsActivity
+import org.mockito.Mockito
+
+class MockSettingsActivity : SettingsActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        Settings.setFSGetter(MockFileSystem.MockFSGetter)
+        Settings.createDefaultSettings().save(Mockito.mock(Context::class.java))
+        super.onCreate(savedInstanceState)
+    }
+}

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/SettingsBuilderTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/SettingsBuilderTest.kt
@@ -12,6 +12,6 @@ class SettingsBuilderTest {
         val settings = Settings.createDefaultSettings()
         val settingsBuilder = SettingsBuilder(settings)
         val settings2 = settingsBuilder.language(Language.FRENCH).build()
-        Assert.assertEquals(Language.FRENCH, settings2.getLanguage())
+        Assert.assertEquals(Language.FRENCH, settings2.language)
     }
 }

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/SettingsTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/SettingsTest.kt
@@ -12,7 +12,7 @@ class SettingsTest {
     @Test
     fun getCorrectLanguage(){
         val settings = Settings(Language.FRENCH)
-        Assert.assertEquals(Language.FRENCH, settings.getLanguage())
+        Assert.assertEquals(Language.FRENCH, settings.language)
     }
 
     @Test
@@ -22,7 +22,7 @@ class SettingsTest {
         val settings = Settings(Language.FRENCH)
         settings.save(ctx)
         val settings2 = companion.loadOrDefault(ctx)
-        Assert.assertEquals(Language.FRENCH, settings2.getLanguage())
+        Assert.assertEquals(Language.FRENCH, settings2.language)
     }
 
 

--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/SettingsTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/SettingsTest.kt
@@ -1,13 +1,19 @@
 package com.github.fribourgsdp.radio.unit
 
 import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import com.github.fribourgsdp.radio.config.Settings
 import com.github.fribourgsdp.radio.config.language.Language
+import com.github.fribourgsdp.radio.mockimplementations.MockFileSystem
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 
 class SettingsTest {
+    @Before
+    fun setup() {
+        Settings.setFSGetter(MockFileSystem.MockFSGetter)
+    }
 
     @Test
     fun getCorrectLanguage(){
@@ -17,13 +23,11 @@ class SettingsTest {
 
     @Test
     fun saveAndLoadWorkCorrectly(){
-        val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val companion = Settings.Companion
+        val ctx = Mockito.mock(Context::class.java)
         val settings = Settings(Language.FRENCH)
         settings.save(ctx)
-        val settings2 = companion.loadOrDefault(ctx)
+        val settings2 = Settings.loadOrDefault(ctx)
         Assert.assertEquals(Language.FRENCH, settings2.language)
     }
-
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,9 @@
         <activity
             android:name=".mockimplementations.MockUserProfileActivity"
             android:exported="false" />
+        <activity
+            android:name=".mockimplementations.MockSettingsActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
@@ -11,14 +11,11 @@ import kotlinx.serialization.json.Json
 @Serializable
 class Settings(val language : Language) : SavesToFileSystem<Settings>(SETTINGS_DATA_PATH) {
 
-
-    companion object {
+    companion object : LoadsFromFileSystem<Settings>(){
         const val SETTINGS_DATA_PATH = "settings_data_file"
-        private var fileSystemGetter: FileSystem.FileSystemGetter =
-            AppSpecificFileSystem.AppSpecificFSGetter
+        override var defaultPath = SETTINGS_DATA_PATH
 
-
-        fun load(context: Context, path: String = SETTINGS_DATA_PATH) : Settings {
+        override fun load(context: Context, path: String) : Settings {
             val fs = fileSystemGetter.getFileSystem(context)
             return Json.decodeFromString(fs.read(path))
         }
@@ -33,12 +30,9 @@ class Settings(val language : Language) : SavesToFileSystem<Settings>(SETTINGS_D
         fun createDefaultSettings(): Settings {
             return Settings(Language.ENGLISH)
         }
-
-
     }
 
-
-    fun save(context: Context, path: String = SETTINGS_DATA_PATH){
+    override fun save(context: Context, path: String){
         val fs = fileSystemGetter.getFileSystem(context)
         fs.write(path, Json.encodeToString(this))
     }

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
@@ -23,7 +23,9 @@ data class Settings(val language : Language) : SavesToFileSystem<Settings>(SETTI
         fun loadOrDefault(context: Context) : Settings {
             return try { load(context)
             } catch (e: java.io.FileNotFoundException) {
-                createDefaultSettings()
+                val defaultSettings = createDefaultSettings()
+                defaultSettings.save(context)
+                defaultSettings
             }
         }
 

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable
-class Settings(private var language : Language) {
+class Settings(val language : Language) : SavesToFileSystem<Settings>(SETTINGS_DATA_PATH) {
 
 
     companion object {
@@ -23,14 +23,12 @@ class Settings(private var language : Language) {
             return Json.decodeFromString(fs.read(path))
         }
 
-
         fun loadOrDefault(context: Context) : Settings {
             return try { load(context)
             } catch (e: java.io.FileNotFoundException) {
                 createDefaultSettings()
             }
         }
-
 
         fun createDefaultSettings(): Settings {
             return Settings(Language.ENGLISH)
@@ -44,10 +42,4 @@ class Settings(private var language : Language) {
         val fs = fileSystemGetter.getFileSystem(context)
         fs.write(path, Json.encodeToString(this))
     }
-
-    fun getLanguage(): Language {
-        return language
-    }
-
-
 }

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/Settings.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable
-class Settings(val language : Language) : SavesToFileSystem<Settings>(SETTINGS_DATA_PATH) {
+data class Settings(val language : Language) : SavesToFileSystem<Settings>(SETTINGS_DATA_PATH) {
 
     companion object : LoadsFromFileSystem<Settings>(){
         const val SETTINGS_DATA_PATH = "settings_data_file"

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/SettingsActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/SettingsActivity.kt
@@ -9,7 +9,7 @@ import com.github.fribourgsdp.radio.config.language.Language
 import com.github.fribourgsdp.radio.config.language.LanguageManager
 
 
-class SettingsActivity : MyAppCompatActivity() {
+open class SettingsActivity : MyAppCompatActivity() {
 
 
     private lateinit var spinnerLanguage: Spinner

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/SettingsActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/SettingsActivity.kt
@@ -27,7 +27,7 @@ class SettingsActivity : MyAppCompatActivity() {
         val settings = Settings.loadOrDefault(this)
         this.settings = settings
         settingsBuilder = SettingsBuilder(settings)
-        initLanguageSpinner(settings.getLanguage())
+        initLanguageSpinner(settings.language)
 
         initSaveSettingsButton()
 

--- a/app/src/main/java/com/github/fribourgsdp/radio/config/SettingsBuilder.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/config/SettingsBuilder.kt
@@ -7,7 +7,7 @@ class SettingsBuilder {
     private lateinit var language : Language
 
     constructor(settings : Settings){
-        language = settings.getLanguage()
+        language = settings.language
     }
 
     fun language(language : Language): SettingsBuilder {

--- a/app/src/main/java/com/github/fribourgsdp/radio/data/User.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/data/User.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.json.Json
  *
  * @constructor creates a User
  */
-data class User (var name: String, val color: Int) {
+data class User (var name: String, val color: Int) : SavesToFileSystem<User>() {
     init {
         require(name.isNotEmpty() && name.isNotBlank())
     }
@@ -44,27 +44,27 @@ data class User (var name: String, val color: Int) {
     var id : String = "def"
 
 
-    companion object {
+    companion object : LoadsFromFileSystem<User>() {
         const val USER_DATA_PATH = "user_data_file"
-        private var fileSystemGetter: FileSystem.FileSystemGetter =
-            AppSpecificFileSystem
+
+        override fun load(context: Context, path: String) : User {
+            val fs = fileSystemGetter.getFileSystem(context)
+            return Json.decodeFromString(fs.read(path))
+        }
 
         /**
-         * loads a user from the app-specific storage on the device.
-         * There can only be a single User stored on the device at the default path
+         * loads a user from the app-specific storage on the device at the default path.
+         * There can only be a single User stored on the device at this path
          * which is written with [User].save().
          * This function can be used from any activity of the app and retrieves the same data
          *
          * @param context the context to use for loading from a file (usually this in an activity)
-         * @param path a specific path in app-specific storage if we don't want to use the default
-         *      user location
          * @throws java.io.FileNotFoundException
          *
          * @return the user saved on the device
          */
-        fun load(context: Context, path: String = USER_DATA_PATH) : User {
-            val fs = fileSystemGetter.getFileSystem(context)
-            return Json.decodeFromString(fs.read(path))
+        fun load(context: Context) : User {
+            return load(context, USER_DATA_PATH)
         }
 
         /**
@@ -104,30 +104,23 @@ data class User (var name: String, val color: Int) {
                 (Random.nextInt(100, 200) shl 16) or
                 (Random.nextInt(100, 200) shl 8) or
                 Random.nextInt(100, 200)
+    }
 
-        /**
-         * changes the default app specific file system wrapper to a custom one
-         * useful for tests
-         *
-         * @param fsg the [FileSystem.FileSystemGetter] to will replace the current implementation
-         */
-        fun setFSGetter(fsg: FileSystem.FileSystemGetter) {
-            fileSystemGetter = fsg
-        }
+
+    override fun save(context: Context, path: String){
+        val fs = fileSystemGetter.getFileSystem(context)
+        fs.write(path, Json.encodeToString(this))
     }
 
     /**
-     * saves a user to the app-specific storage on the device.
+     * saves a user to the app-specific storage on the device at the default path.
      * There can only be a single User stored on the device at the default path, so this can overwrite
      * This function can be used from any activity of the app to save data accessible from anywhere
      *
      * @param context the context to use for saving to a file (usually this in an activity)
-     * @param path a specific path in app-specific storage if we don't want to use the default
-     *      user location
      */
-    fun save(context: Context, path: String = USER_DATA_PATH){
-        val fs = fileSystemGetter.getFileSystem(context)
-        fs.write(path, Json.encodeToString(this))
+    fun save(context: Context){
+        save(context, USER_DATA_PATH)
     }
 
     /**

--- a/app/src/main/java/com/github/fribourgsdp/radio/data/User.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/data/User.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.json.Json
  *
  * @constructor creates a User
  */
-data class User (var name: String, val color: Int) : SavesToFileSystem<User>() {
+data class User (var name: String, val color: Int) : SavesToFileSystem<User>(USER_DATA_PATH) {
     init {
         require(name.isNotEmpty() && name.isNotBlank())
     }
@@ -46,25 +46,11 @@ data class User (var name: String, val color: Int) : SavesToFileSystem<User>() {
 
     companion object : LoadsFromFileSystem<User>() {
         const val USER_DATA_PATH = "user_data_file"
+        override var defaultPath = USER_DATA_PATH
 
         override fun load(context: Context, path: String) : User {
             val fs = fileSystemGetter.getFileSystem(context)
             return Json.decodeFromString(fs.read(path))
-        }
-
-        /**
-         * loads a user from the app-specific storage on the device at the default path.
-         * There can only be a single User stored on the device at this path
-         * which is written with [User].save().
-         * This function can be used from any activity of the app and retrieves the same data
-         *
-         * @param context the context to use for loading from a file (usually this in an activity)
-         * @throws java.io.FileNotFoundException
-         *
-         * @return the user saved on the device
-         */
-        fun load(context: Context) : User {
-            return load(context, USER_DATA_PATH)
         }
 
         /**
@@ -110,17 +96,6 @@ data class User (var name: String, val color: Int) : SavesToFileSystem<User>() {
     override fun save(context: Context, path: String){
         val fs = fileSystemGetter.getFileSystem(context)
         fs.write(path, Json.encodeToString(this))
-    }
-
-    /**
-     * saves a user to the app-specific storage on the device at the default path.
-     * There can only be a single User stored on the device at the default path, so this can overwrite
-     * This function can be used from any activity of the app to save data accessible from anywhere
-     *
-     * @param context the context to use for saving to a file (usually this in an activity)
-     */
-    fun save(context: Context){
-        save(context, USER_DATA_PATH)
     }
 
     /**

--- a/app/src/main/java/com/github/fribourgsdp/radio/data/User.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/data/User.kt
@@ -65,7 +65,9 @@ data class User (var name: String, val color: Int) : SavesToFileSystem<User>(USE
                 Tasks.forResult(load(context))
             } catch (e: java.io.FileNotFoundException) {
                 createDefaultUser()
-                //User("No User Found", User.generateColor())
+                    .addOnSuccessListener { user ->
+                    user.save(context)
+                }
             }
         }
 

--- a/app/src/main/java/com/github/fribourgsdp/radio/persistence/LoadsFromFileSystem.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/persistence/LoadsFromFileSystem.kt
@@ -1,7 +1,6 @@
 package com.github.fribourgsdp.radio.persistence
 
 import android.content.Context
-import com.github.fribourgsdp.radio.data.User
 
 /**
  * should be extended by the companion object of classes which use a filesystem
@@ -9,6 +8,7 @@ import com.github.fribourgsdp.radio.data.User
  */
 abstract class LoadsFromFileSystem<T : SavesToFileSystem<T>> {
     protected var fileSystemGetter: FileSystem.FileSystemGetter = AppSpecificFileSystem
+    protected open var defaultPath: String = "default"+this.toString()+"file"
 
     /**
      * changes the default app specific file system wrapper to a custom one
@@ -23,7 +23,7 @@ abstract class LoadsFromFileSystem<T : SavesToFileSystem<T>> {
     /**
      * loads a dataclass from the app-specific storage on the device.
      * There can only be a single datacalass stored on the device at per path
-     * which is written with [User].save().
+     * which is written with [SavesToFileSystem].save().
      * This function can be used from any activity of the app and retrieves the same data
      *
      * @param context the context to use for loading from a file (usually this in an activity)
@@ -34,4 +34,19 @@ abstract class LoadsFromFileSystem<T : SavesToFileSystem<T>> {
      * @return the dataclass saved on the device
      */
     abstract fun load(context: Context, path: String) : T
+
+    /**
+     * loads a dataclass from the app-specific storage on the device at the default path.
+     * There can only be a single dataclass instance stored on the device at this path
+     * which is written with [SavesToFileSystem].save().
+     * This function can be used from any activity of the app and retrieves the same data
+     *
+     * @param context the context to use for loading from a file (usually this in an activity)
+     * @throws java.io.FileNotFoundException
+     *
+     * @return the user saved on the device
+     */
+    fun load(context: Context): T {
+        return load(context, defaultPath)
+    }
 }

--- a/app/src/main/java/com/github/fribourgsdp/radio/persistence/LoadsFromFileSystem.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/persistence/LoadsFromFileSystem.kt
@@ -1,0 +1,37 @@
+package com.github.fribourgsdp.radio.persistence
+
+import android.content.Context
+import com.github.fribourgsdp.radio.data.User
+
+/**
+ * should be extended by the companion object of classes which use a filesystem
+ * to save an instance of themselves.
+ */
+abstract class LoadsFromFileSystem<T : SavesToFileSystem<T>> {
+    protected var fileSystemGetter: FileSystem.FileSystemGetter = AppSpecificFileSystem
+
+    /**
+     * changes the default app specific file system wrapper to a custom one
+     * useful for tests
+     *
+     * @param fsg the [FileSystem.FileSystemGetter] to will replace the current implementation
+     */
+    fun setFSGetter(fsg: FileSystem.FileSystemGetter) {
+        fileSystemGetter = fsg
+    }
+
+    /**
+     * loads a dataclass from the app-specific storage on the device.
+     * There can only be a single datacalass stored on the device at per path
+     * which is written with [User].save().
+     * This function can be used from any activity of the app and retrieves the same data
+     *
+     * @param context the context to use for loading from a file (usually this in an activity)
+     * @param path a specific path in app-specific storage if we don't want to use the default
+     *      user location
+     * @throws java.io.FileNotFoundException
+     *
+     * @return the dataclass saved on the device
+     */
+    abstract fun load(context: Context, path: String) : T
+}

--- a/app/src/main/java/com/github/fribourgsdp/radio/persistence/SavesToFileSystem.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/persistence/SavesToFileSystem.kt
@@ -1,0 +1,22 @@
+package com.github.fribourgsdp.radio.persistence
+
+import android.content.Context
+
+/**
+ * should be extended by classes which use a filesystem to save an instance of themselves.
+ * A class which extends this function should also extend the FileSystemLoader class
+ * to get access to the fileSystemGetter.
+ */
+abstract class SavesToFileSystem<T> {
+    /**
+     * saves a dataclass to the app-specific storage on the device.
+     * There can only be a single dataclass stored on the device at the default path.
+     * This function can be used from any activity of the app to save data accessible from anywhere
+     *
+     * @param context the context to use for saving to a file (usually this in an activity)
+     * @param path a specific path in app-specific storage if we don't want to use the default
+     *      user location
+     */
+    abstract fun save(context: Context, path: String)
+
+}

--- a/app/src/main/java/com/github/fribourgsdp/radio/persistence/SavesToFileSystem.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/persistence/SavesToFileSystem.kt
@@ -9,8 +9,7 @@ import kotlinx.serialization.Serializable
  * A class which extends this function should also extend the FileSystemLoader class
  * to get access to the fileSystemGetter.
  */
-abstract class SavesToFileSystem<T>(private val defaultPath: String) {
-
+abstract class SavesToFileSystem<T>(protected val defaultPath: String) {
 
     /**
      * saves a dataclass to the app-specific storage on the device.

--- a/app/src/main/java/com/github/fribourgsdp/radio/persistence/SavesToFileSystem.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/persistence/SavesToFileSystem.kt
@@ -1,13 +1,17 @@
 package com.github.fribourgsdp.radio.persistence
 
 import android.content.Context
+import kotlinx.serialization.Serializable
 
+@Serializable
 /**
  * should be extended by classes which use a filesystem to save an instance of themselves.
  * A class which extends this function should also extend the FileSystemLoader class
  * to get access to the fileSystemGetter.
  */
-abstract class SavesToFileSystem<T> {
+abstract class SavesToFileSystem<T>(private val defaultPath: String) {
+
+
     /**
      * saves a dataclass to the app-specific storage on the device.
      * There can only be a single dataclass stored on the device at the default path.
@@ -19,4 +23,15 @@ abstract class SavesToFileSystem<T> {
      */
     abstract fun save(context: Context, path: String)
 
+    /**
+     * saves a dataclass instance to the app-specific storage on the device at the default path.
+     * There can only be a single dataclass instance stored on the device at the default path,
+     * so this can overwrite a previous instance.
+     * This function can be used from any activity of the app to save data accessible from anywhere.
+     *
+     * @param context the context to use for saving to a file (usually this in an activity)
+     */
+    fun save(context: Context){
+        save(context, defaultPath)
+    }
 }


### PR DESCRIPTION
Fixes the Settings unit tests which were saving to app specific file system instead of the mock file system which affected the settings for all tests run after the settings test. This can lead to undefined behaviour as test order is not guaranteed. 
Implements a nice wrapper for classes which use the file system to prevent code duplication ;)