### PR TITLE
Bugfix - Correct message on game over

### DIFF
--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/PlayerGameHandlerTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/unit/PlayerGameHandlerTest.kt
@@ -326,6 +326,7 @@ class PlayerGameHandlerTest {
         handler.handleSnapshot(mockSnapshot)
 
         assertTrue(view.gameOver)
+        assertFalse(view.crashed)
     }
 
     @Test
@@ -410,6 +411,19 @@ class PlayerGameHandlerTest {
         Thread.sleep(sleepingTime)
 
         // Game crashed
+        assertTrue(view.gameOver)
+        assertTrue(view.crashed)
+    }
+
+    @Test
+    fun gameCrashedOnGameNotValid() {
+        val view = FakeGameView()
+        val handler = PlayerGameHandler(ctx, 0, view)
+
+        `when`(mockSnapshot.getBoolean("validity")).thenReturn(false)
+
+        handler.handleSnapshot(mockSnapshot)
+
         assertTrue(view.gameOver)
         assertTrue(view.crashed)
     }

--- a/app/src/main/java/com/github/fribourgsdp/radio/game/handler/PlayerGameHandler.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/game/handler/PlayerGameHandler.kt
@@ -41,7 +41,7 @@ class PlayerGameHandler(
             val gameStillValid = snapshot.getBoolean("validity")!!
             scores = snapshot.get("scores") as HashMap<String, Long>
             if (snapshot.getBoolean("finished")!! || !gameStillValid) {
-                view.gameOver(scores!!, gameStillValid)
+                view.gameOver(scores!!, !gameStillValid)
                 return
             }
 


### PR DESCRIPTION
Correct the way the handler asks the view to end the game. (A mixup in the arguments was the cause)