### PR TITLE
Fix playlist visualization not updating after google sign in

### DIFF
--- a/app/src/androidTest/java/com/github/fribourgsdp/radio/ui/PlaylistRecyclerViewTest.kt
+++ b/app/src/androidTest/java/com/github/fribourgsdp/radio/ui/PlaylistRecyclerViewTest.kt
@@ -102,4 +102,31 @@ class PlaylistRecyclerViewTest {
                 .check(ViewAssertions.matches(ViewMatchers.withText(songName)))
         }
     }
+
+    @Test
+    fun recyclerViewTestDeleteUpdatesInstantly() {
+        val firebaseAuth = FirebaseAuth.getInstance()
+        val task = Tasks.withTimeout(
+            firebaseAuth.signInWithEmailAndPassword(
+                "test@test.com",
+                "test123!!!"
+            ), 10, TimeUnit.SECONDS
+        )
+        Tasks.await(task)
+
+        val context: Context = ApplicationProvider.getApplicationContext()
+
+        val intent = Intent(context, MockUserProfileActivity::class.java)
+
+        ActivityScenario.launch<MockUserProfileActivity>(intent).use { scenario ->
+            Espresso.onView(withId(R.id.playlist_recycler_view))
+                .check(matches(hasChildCount(1)))
+            Espresso.onView(withId(R.id.playlist_recycler_view))
+                .perform(RecyclerViewActions.actionOnItemAtPosition<ViewHolder>(0, click()))
+            Espresso.onView(withId(R.id.deleteButton))
+                .perform(click())
+            Espresso.onView(withId(R.id.playlist_recycler_view))
+                .check(matches(hasChildCount(0)))
+        }
+    }
 }

--- a/app/src/main/java/com/github/fribourgsdp/radio/data/view/PlaylistsFragmentHolderActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/data/view/PlaylistsFragmentHolderActivity.kt
@@ -1,5 +1,6 @@
 package com.github.fribourgsdp.radio.data.view
 
+import android.content.Intent
 import android.os.Bundle
 import com.github.fribourgsdp.radio.config.MyAppCompatActivity
 import com.github.fribourgsdp.radio.util.MyFragment
@@ -9,10 +10,15 @@ class PlaylistsFragmentHolderActivity : MyAppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_playlists_fragment_holder)
-
         //initialise songs recycler view fragment
         val bundle = Bundle()
         bundle.putString(PLAYLIST_DATA, intent.getStringExtra(PLAYLIST_DATA))
         MyFragment.beginTransaction<PlaylistSongsFragment>(supportFragmentManager, bundle)
+    }
+
+    override fun onBackPressed() {
+        val intent = Intent(this, UserProfileActivity::class.java)
+        startActivity(intent)
+        finish()
     }
 }

--- a/app/src/main/java/com/github/fribourgsdp/radio/data/view/UserPlaylistsFragment.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/data/view/UserPlaylistsFragment.kt
@@ -18,26 +18,18 @@ const val PLAYLIST_DATA = "com.github.fribourgsdp.radio.PLAYLIST_INNER_DATA"
 class UserPlaylistsFragment : MyFragment(R.layout.fragment_user_playlists_display),
     OnClickListener {
     private lateinit var user: User
-    private lateinit var userPlaylists: List<Playlist>
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let { args ->
-            args.getString(USER_DATA).let { serializedUser ->
-                user = Json.decodeFromString(serializedUser!!)
-                userPlaylists = user.getPlaylists().toList()
-            }
-        }
-    }
+    private lateinit var userPlaylists: MutableList<Playlist>
+    private lateinit var songDisplay: RecyclerView
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        loadData()
         initializeRecyclerView()
     }
 
     private fun initializeRecyclerView() {
-        val songDisplay : RecyclerView = requireView().findViewById(R.id.playlist_recycler_view)
-        songDisplay.adapter = PlaylistAdapter(user.getPlaylists().toList(), this)
+        songDisplay = requireView().findViewById(R.id.playlist_recycler_view)
+        songDisplay.adapter = PlaylistAdapter(userPlaylists, this)
         songDisplay.layoutManager = (LinearLayoutManager(activity))
         songDisplay.setHasFixedSize(true)
     }
@@ -48,5 +40,20 @@ class UserPlaylistsFragment : MyFragment(R.layout.fragment_user_playlists_displa
                 .putExtra(PLAYLIST_DATA, userPlaylists[position].name)
             startActivity(intent)
         }
+    }
+
+    fun notifyUserChanged() {
+        loadData()
+        songDisplay.adapter?.notifyDataSetChanged()
+    }
+
+    private fun loadData(){
+        user = User.load(requireContext())
+        userPlaylists = user.getPlaylists().toMutableList()
+    }
+
+    override fun onResume() {
+        notifyUserChanged()
+        super.onResume()
     }
 }

--- a/app/src/main/java/com/github/fribourgsdp/radio/data/view/UserProfileActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/data/view/UserProfileActivity.kt
@@ -30,6 +30,7 @@ const val REDIRECT_URI = "com.github.fribourgsdp.radio://callback"
 const val SCOPES = "playlist-read-private,playlist-read-collaborative"
 const val RECREATE_USER = "com.github.fribourgsdp.radio.avoidRecreatingUser"
 const val USER_DATA = "com.github.fribourgsdp.radio.data.view.USER_DATA"
+const val FRAGMENT_TAG = "playlistsRVFragment"
 
 open class UserProfileActivity : MyAppCompatActivity(), KeepOrDismissPlaylistDialog.OnPickListener, MergeDismissImportPlaylistDialog.OnPickListener, DatabaseHolder {
     private lateinit var user : User
@@ -65,10 +66,9 @@ open class UserProfileActivity : MyAppCompatActivity(), KeepOrDismissPlaylistDia
             spotifyStatusText.apply { text = if (user.linkedSpotify) getString(R.string.spotify_linked) else getString(R.string.spotify_unlinked) }
             userIcon.colorFilter = PorterDuffColorFilter(user.color, PorterDuff.Mode.ADD)
             //initialise playlists recycler view fragment
-            val bundle = Bundle()
-            bundle.putString(USER_DATA, Json.encodeToString(user))
-            MyFragment.beginTransaction<UserPlaylistsFragment>(supportFragmentManager, bundle)
-
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.container, UserPlaylistsFragment::class.java, Bundle(), "playlistsFragment")
+                .commit()
         }
 
         launchSpotifyButton.setOnClickListener {
@@ -114,6 +114,10 @@ open class UserProfileActivity : MyAppCompatActivity(), KeepOrDismissPlaylistDia
         userIcon = findViewById(R.id.userIcon)
     }
 
+    private fun updateFragment() {
+        val fragment = supportFragmentManager.findFragmentByTag(FRAGMENT_TAG)!! as UserPlaylistsFragment
+        fragment.notifyUserChanged()
+    }
 
     private fun updateUser(){
         user.name = usernameField.text.toString()


### PR DESCRIPTION
If merged, this PR will fix the bug of the recyclerview displaying a user's playlists not updating when a playlist is deleted, as well as provide methods to easily fix the bug of playlists not updating in that same recyclerview when a user is imported