### PR TITLE
Correct disappearing EditText view

### DIFF
--- a/app/src/main/java/com/github/fribourgsdp/radio/game/GameActivity.kt
+++ b/app/src/main/java/com/github/fribourgsdp/radio/game/GameActivity.kt
@@ -164,10 +164,7 @@ open class GameActivity : AppCompatActivity(), GameView, Timer.Listener {
         showLyricsButton.visibility = View.GONE
 
         // Show the edit text and the submit button instead
-        songGuessEditText.apply {
-            text.clear()
-            visibility = View.VISIBLE
-        }
+        songGuessEditText.visibility = View.VISIBLE
         songGuessSubmitButton.visibility = View.VISIBLE
     }
 
@@ -277,6 +274,10 @@ open class GameActivity : AppCompatActivity(), GameView, Timer.Listener {
             }
             false
         }
+
+        // clear edittext on click
+        songGuessEditText.setOnClickListener { songGuessEditText.text.clear() }
+
         muteButton = findViewById(R.id.muteChannelButton)
         muteButton.setOnClickListener {
             voiceChannel.mute()


### PR DESCRIPTION
When guessing after inputting something else in the previous turn, the `EditText` was disappearing. This fixes this bug as it clear the input only on click.